### PR TITLE
hotfix: NotInjectCSS

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,10 +1,13 @@
 {
-    "manifest_version": 3,
-    "name": "ScreenCapture Test",
-    "version": "1.0",
-    "description": "ScreenCapture Test",
-    "permissions": ["activeTab", "scripting", "downloads"],
-    "action": {
-      "default_popup": "popup.html"
-    }
+  "manifest_version": 3,
+  "name": "ScreenCapture Test",
+  "version": "1.0",
+  "description": "ScreenCapture Test",
+  "permissions": ["activeTab", "scripting", "downloads", "tabs"],
+  "host_permissions": [
+    "*://*.wikidot.com/*"
+  ],
+  "action": {
+    "default_popup": "popup.html"
   }
+}

--- a/src/popup.js
+++ b/src/popup.js
@@ -2,16 +2,11 @@ document.getElementById('btn').addEventListener('click', async () => {
 
     (async () => {
         const sleep = (second) => new Promise(resolve => setTimeout(resolve, second * 1000))
-
-        chrome.tabs.query({ active: true }, function (tabs) {
-            let tab = tabs[0];
-            chrome.scripting.insertCSS(
-                {
-                    target: { tabId: tab.id },
-                    files: ["inject.css"]
-                }
-            );
-        });
+        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        chrome.scripting.insertCSS({
+            target: { tabId: tab.id },
+            files: ['inject.css'],
+          });
         await sleep(0.1)
         chrome.tabs.captureVisibleTab((url) => {
             ImgB64Resize(url, 710, 399.375,


### PR DESCRIPTION
* ActiveTabの取得方法が異なっていたため最後のタブにアクセスするようになってしまっていた．
https://github.com/RTa-technology/theme-screenshot/blob/826ef5064574848199558a550bd58c78d1f697bc/src/popup.js#L5
にて改善．